### PR TITLE
Fix ttbar gen identification when there's B from ISR or W decays

### DIFF
--- a/interface/Indices.h
+++ b/interface/Indices.h
@@ -82,6 +82,7 @@ namespace TTAnalysis {
 
 
   enum TTDecayType {
+    UnknownTT = -1,
     NotTT = 0,
     Hadronic,
     Semileptonic_e,

--- a/interface/TTAnalyzer.h
+++ b/interface/TTAnalyzer.h
@@ -124,7 +124,7 @@ class TTAnalyzer: public Framework::Analyzer {
         BRANCH(gen_neutrino_tbar, uint16_t); // Index of the neutrino from the anti-top decay chain
         BRANCH(gen_neutrino_tbar_beforeFSR, uint16_t); // Index of the neutrino from the anti-top decay chain, before any FSR
 
-        BRANCH(gen_ttbar_decay_type, uint16_t); // Type of ttbar decay. Can take any values from TTDecayType enum
+        BRANCH(gen_ttbar_decay_type, char); // Type of ttbar decay. Can take any values from TTDecayType enum
 
         BRANCH(gen_ttbar_beforeFSR_p4, LorentzVector);
         BRANCH(gen_ttbar_p4, LorentzVector);

--- a/test/TTConfigurationMC.py
+++ b/test/TTConfigurationMC.py
@@ -49,8 +49,20 @@ process = Framework.create(False, eras.Run2_25ns, '74X_mcRun2_asymptotic_v2', cm
 
 Framework.schedule(process, ['tt'])
 
+#process.source.firstEvent = cms.untracked.uint32(13083444)
+#process.source.firstLuminosityBlock = cms.untracked.uint32(52386)
+
+# Tricky gen event from /store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/00000/0014DC94-DC5C-E511-82FB-7845C4FC39F5.root
+# First one is g g -> t tbar with one W -> bbar c
+# Second is b bar -> t tbar semi-leptonic
+#process.source.eventsToProcess = cms.untracked.VEventRange(
+        #'1:52386:13083444',
+        #'1:34020:8496854'
+        #)
+#process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
 process.source.fileNames = cms.untracked.vstring(
         'file:/nfs/scratch/fynu/swertz/CMSSW_7_4_15/src/cp3_llbb/TTAnalysis/test/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_miniAODv2_oneFile.root'
         )
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(2000))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))


### PR DESCRIPTION
As title says.

Some events are more trickier than others, especially those where there's more than 2 Bs.
