### PR TITLE
Fixed gen info - maybe?

### DIFF
--- a/interface/Defines.h
+++ b/interface/Defines.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// Debugging macros
+
+// #define _TT_DEBUG_
+#define TT_MTT_DEBUG (false)
+#define TT_HLT_DEBUG (false)
+#define TT_GEN_DEBUG (false)
+
+
+#if TT_GEN_DEBUG
+#define FILL_GEN_COLL( X ) \
+    if (flags.isLastCopy()) { \
+        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+        gen_##X = gen_index; \
+        gen_index++; \
+        std::cout << "Assigning gen_" #X " = " << i << " (" << pdg_id << ")" << std::endl; \
+    } \
+    if (flags.isFirstCopy()) { \
+        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+        gen_##X##_beforeFSR = gen_index; \
+        gen_index++; \
+        std::cout << "Assigning gen_" #X "_beforeFSR = " << i << " (" << pdg_id << ")" << std::endl; \
+    }
+#else
+#define FILL_GEN_COLL( X ) \
+    if (flags.isLastCopy()) { \
+        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+        gen_##X = gen_index; \
+        gen_index++; \
+    } \
+    if (flags.isFirstCopy()) { \
+        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+        gen_##X##_beforeFSR = gen_index; \
+        gen_index++; \
+    }
+#endif
+
+// Assign index to X if it's empty, or Y if not
+#if TT_GEN_DEBUG
+#define FILL_GEN_COLL2(X, Y, ERROR) \
+    if (flags.isLastCopy()) { \
+        if (gen_##X == -1){ \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##X = gen_index; \
+            gen_index++; \
+            std::cout << "Assigning gen_" #X " = " << i << " (" << pdg_id << ")" << std::endl; \
+        } else if (gen_##Y == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##Y = gen_index; \
+            gen_index++; \
+            std::cout << "Assigning gen_" #Y " = " << i << " (" << pdg_id << ")" << std::endl; \
+        } else \
+            std::cout << ERROR << std::endl; \
+    } \
+    if (flags.isFirstCopy()) { \
+        if (gen_##X##_beforeFSR == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##X##_beforeFSR = gen_index; \
+            gen_index++; \
+            std::cout << "Assigning gen_" #X "_beforeFSR = " << i << " (" << pdg_id << ")" << std::endl; \
+        } else if (gen_##Y##_beforeFSR == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##Y##_beforeFSR = gen_index; \
+            gen_index++; \
+            std::cout << "Assigning gen_" #Y "_beforeFSR = " << i << " (" << pdg_id << ")" << std::endl; \
+        } else \
+            std::cout << ERROR << std::endl; \
+    }
+#else
+#define FILL_GEN_COLL2(X, Y, ERROR) \
+    if (flags.isLastCopy()) { \
+        if (gen_##X == -1){ \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##X = gen_index; \
+            gen_index++; \
+        } else if (gen_##Y == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##Y = gen_index; \
+            gen_index++; \
+        } else \
+            std::cout << ERROR << std::endl; \
+    } \
+    if (flags.isFirstCopy()) { \
+        if (gen_##X##_beforeFSR == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##X##_beforeFSR = gen_index; \
+            gen_index++; \
+        } else if (gen_##Y##_beforeFSR == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
+            gen_##Y##_beforeFSR = gen_index; \
+            gen_index++; \
+        } else \
+            std::cout << ERROR << std::endl; \
+    }
+#endif

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -29,8 +29,10 @@ namespace TTAnalysis {
 
   struct GenParticle: BaseObject {
     GenParticle() {}
-    GenParticle(myLorentzVector p4, int16_t pdg_id): BaseObject(p4), pdg_id(pdg_id) {}
+    GenParticle(myLorentzVector p4, int16_t pdg_id, int32_t pruned_idx): BaseObject(p4), pdg_id(pdg_id), pruned_idx(pruned_idx) {}
     int16_t pdg_id;
+    // This will be used to check the decay chains of the particles, and not stored in the tree
+    int32_t pruned_idx;
   };
 
   struct Lepton: BaseObject {

--- a/plugins/TTAnalyzer.cc
+++ b/plugins/TTAnalyzer.cc
@@ -899,12 +899,12 @@ after_hlt_matching:
 
 #define FILL_GEN_COLL( X ) \
     if (flags.isLastCopy()) { \
-        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id) ); \
+        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
         gen_##X = gen_index; \
         gen_index++; \
     } \
     if (flags.isFirstCopy()) { \
-        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id) ); \
+        genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
         gen_##X##_beforeFSR = gen_index; \
         gen_index++; \
     }
@@ -912,24 +912,24 @@ after_hlt_matching:
 // Assign index to X if it's empty, or Y if not
 #define FILL_GEN_COLL2(X, Y, ERROR) \
     if (flags.isLastCopy()) { \
-        if (gen_##X == 0){ \
-            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id) ); \
+        if (gen_##X == -1){ \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
             gen_##X = gen_index; \
             gen_index++; \
-        } else if (gen_##Y == 0) { \
-            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id) ); \
+        } else if (gen_##Y == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
             gen_##Y = gen_index; \
             gen_index++; \
         } else \
             std::cout << ERROR << std::endl; \
     } \
     if (flags.isFirstCopy()) { \
-        if (gen_##X##_beforeFSR == 0) { \
-            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id) ); \
+        if (gen_##X##_beforeFSR == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
             gen_##X##_beforeFSR = gen_index; \
             gen_index++; \
-        } else if (gen_##Y##_beforeFSR == 0) { \
-            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id) ); \
+        } else if (gen_##Y##_beforeFSR == -1) { \
+            genParticles.push_back( GenParticle(gen_particles.pruned_p4[i], pdg_id, i) ); \
             gen_##Y##_beforeFSR = gen_index; \
             gen_index++; \
         } else \
@@ -1006,8 +1006,8 @@ after_hlt_matching:
             continue;
         }
 
-        bool from_t_decay = pruned_decays_from(i, gen_t);
-        bool from_tbar_decay = pruned_decays_from(i, gen_tbar);
+        bool from_t_decay = pruned_decays_from(i, genParticles[gen_t].pruned_idx);
+        bool from_tbar_decay = pruned_decays_from(i, genParticles[gen_tbar].pruned_idx);
 
         // Only keep particles coming from the tops decay
         if (! from_t_decay && ! from_tbar_decay)
@@ -1030,10 +1030,10 @@ after_hlt_matching:
                     std::cout << "A quark coming from W decay is a b" << std::endl;
 #endif
 
-                    if (! (gen_jet1_tbar_beforeFSR != -1 && pruned_decays_from(i, gen_jet1_tbar_beforeFSR)) &&
-                        ! (gen_jet2_tbar_beforeFSR != -1 && pruned_decays_from(i, gen_jet2_tbar_beforeFSR)) &&
-                        ! (gen_jet1_t_beforeFSR != -1 && pruned_decays_from(i, gen_jet1_t_beforeFSR)) &&
-                        ! (gen_jet2_t_beforeFSR != -1 && pruned_decays_from(i, gen_jet2_t_beforeFSR))) {
+                    if (! (gen_jet1_tbar_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet1_tbar_beforeFSR].pruned_idx)) &&
+                        ! (gen_jet2_tbar_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet2_tbar_beforeFSR].pruned_idx)) &&
+                        ! (gen_jet1_t_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet1_t_beforeFSR].pruned_idx)) &&
+                        ! (gen_jet2_t_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet2_t_beforeFSR].pruned_idx))) {
 #if TT_GEN_DEBUG
                         std::cout << "This after-FSR b quark is not coming from a W decay" << std::endl;
 #endif
@@ -1076,10 +1076,10 @@ after_hlt_matching:
                     std::cout << "A quark coming from W decay is a bbar" << std::endl;
 #endif
 
-                    if (! (gen_jet1_tbar_beforeFSR != -1 && pruned_decays_from(i, gen_jet1_tbar_beforeFSR)) &&
-                        ! (gen_jet2_tbar_beforeFSR != -1 && pruned_decays_from(i, gen_jet2_tbar_beforeFSR)) &&
-                        ! (gen_jet1_t_beforeFSR != -1 && pruned_decays_from(i, gen_jet1_t_beforeFSR)) &&
-                        ! (gen_jet2_t_beforeFSR != -1 && pruned_decays_from(i, gen_jet2_t_beforeFSR))) {
+                    if (! (gen_jet1_tbar_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet1_tbar_beforeFSR].pruned_idx)) &&
+                        ! (gen_jet2_tbar_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet2_tbar_beforeFSR].pruned_idx)) &&
+                        ! (gen_jet1_t_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet1_t_beforeFSR].pruned_idx)) &&
+                        ! (gen_jet2_t_beforeFSR != -1 && pruned_decays_from(i, genParticles[gen_jet2_t_beforeFSR].pruned_idx))) {
 #if TT_GEN_DEBUG
                         std::cout << "This after-fsr b anti-quark is not coming from a W decay" << std::endl;
 #endif

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -28,7 +28,9 @@
   <class name="std::vector<TTAnalysis::TTBar>"/>
   <class name="std::vector<std::vector<TTAnalysis::TTBar>>"/>
   <class name="std::vector<std::vector<std::vector<TTAnalysis::TTBar>>>"/>
-  <class name="TTAnalysis::GenParticle"/>
+  <class name="TTAnalysis::GenParticle">
+    <field name="pruned_idx" transient="true"/>
+  </class>
   <class name="std::vector<TTAnalysis::GenParticle>"/>
 </lcgdict>
 

--- a/test/TTConfigurationData.py
+++ b/test/TTConfigurationData.py
@@ -67,4 +67,4 @@ process.source.fileNames = cms.untracked.vstring(
     '/store/data/Run2015D/DoubleMuon/MINIAOD/16Dec2015-v1/10000/00039A2E-D7A7-E511-98EE-3417EBE64696.root'
     )
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))

--- a/test/TTConfigurationMC.py
+++ b/test/TTConfigurationMC.py
@@ -67,4 +67,4 @@ process.source.fileNames = cms.untracked.vstring(
     '/store/mc/RunIIFall15MiniAODv2/TT_TuneCUETP8M1_13TeV-amcatnlo-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/04D51FB4-B2B8-E511-A399-047D7B881D6A.root'
     )
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))

--- a/test/TTConfigurationMC.py
+++ b/test/TTConfigurationMC.py
@@ -67,4 +67,23 @@ process.source.fileNames = cms.untracked.vstring(
     '/store/mc/RunIIFall15MiniAODv2/TT_TuneCUETP8M1_13TeV-amcatnlo-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/04D51FB4-B2B8-E511-A399-047D7B881D6A.root'
     )
 
+
+## Tricky gen event from /store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/00000/0014DC94-DC5C-E511-82FB-7845C4FC39F5.root
+## First one is g g -> t tbar with one W -> bbar c
+## Second is b bar -> t tbar semi-leptonic
+#process.source.eventsToProcess = cms.untracked.VEventRange(
+#        '1:52386:13083444',
+#        '1:34020:8496854'
+#        )
+
+## Other tricky gen events, with lots of ISR
+## From file:/nfs/scratch/fynu/swertz/CMSSW_7_4_15/src/cp3_llbb/TTAnalysis/test/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_miniAODv2_oneFile.root
+#process.source.eventsToProcess = cms.untracked.VEventRange(
+#        '1:321521:80300260',
+#        '1:357590:89308562',
+#        '1:387992:96901374'
+#        )
+
+#process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))


### PR DESCRIPTION
There was a bug in #33  which I didn't pick up because the number of events I've ran on for the test was too low (I've raised it a bit here).

The problem was because the "pruned_decays_from" macro calls were not correctly moved to the new way of indexing the gen particles, and the effect was a _lot_ of "Error: more than two quarks coming from top decay" messages.

I'm not 100% sure it's fixed though: I still have a few of "Error: more than two quarks coming from top decay/Error: unknown ttbar decay." happening over the 1000 events. Is this something you've seen a lot or only on a few events? I don't see what's still broken though, so probably don't merge this one until we're sure...
