### PR TITLE
Compare to -1 when checking if t and tbar have been found (one forgotten case)

### DIFF
--- a/plugins/TTAnalyzer.cc
+++ b/plugins/TTAnalyzer.cc
@@ -1090,7 +1090,7 @@ after_hlt_matching:
         }
     }
 
-    if (!gen_t || !gen_tbar) {
+    if ((gen_tbar == -1) || (gen_t == -1)) {
 #if TT_GEN_DEBUG
         std::cout << "This is not a ttbar event" << std::endl;
 #endif


### PR DESCRIPTION
see #37 
